### PR TITLE
fix: add missing argument to function simulate_one_avatar

### DIFF
--- a/simulation/arena.py
+++ b/simulation/arena.py
@@ -387,8 +387,10 @@ class Arena(abstract_arena):
         avatar_.write_log(f"Is simulating avatar {avatar_id}")
         avatar_.exit_flag = False
         page_generator = self.page_generator(avatar_id)
+        current_page = 0
         while not avatar_.exit_flag:
         # for i in range(2):
+            current_page += 1
             id_on_page = next(page_generator, []) # get the next page, a list of item ids
             if(len(id_on_page) == 0):
                 break
@@ -404,7 +406,7 @@ class Arena(abstract_arena):
             avatar_.write_log("")
             
             #@ most important
-            response = avatar_.reaction_to_recommended_items(movies_on_page)
+            response = avatar_.reaction_to_recommended_items(movies_on_page, current_page)
 
             avatar_.write_log("")
             avatar_.write_log("=============    Avatar Response    =============")

--- a/simulation/arena.py
+++ b/simulation/arena.py
@@ -396,6 +396,7 @@ class Arena(abstract_arena):
                 break
 
             movies_on_page = [self.movie_detail[idx] for idx in id_on_page]
+            movies_on_page_str = ''.join(movies_on_page) 
             avatar_.write_log("=============    Recommendation Page    =============")
             for idx, movie in enumerate(movies_on_page):
                 if(id_on_page[idx] in self.data.valid_user_list[avatar_id]):
@@ -406,7 +407,7 @@ class Arena(abstract_arena):
             avatar_.write_log("")
             
             #@ most important
-            response = avatar_.reaction_to_recommended_items(movies_on_page, current_page)
+            response = avatar_.reaction_to_recommended_items(movies_on_page_str, current_page)
 
             avatar_.write_log("")
             avatar_.write_log("=============    Avatar Response    =============")


### PR DESCRIPTION
### Reason for Change
- The **"simulate_one_avatar"** function was causing errors due to an incorrect argument.
(missing argument & incorrect argument type)

### Changes Made
- Added the `current_page` argument to the `reaction_to_recommended_items` function.
- Changed the `movies_on_page` parameter type from list to string in the "simulate_one_avatar" function.
- This correction ensures the function operates as expected.

### Testing
- This correction ensures the function operates as expected.
